### PR TITLE
feat: add serverless functions for product service

### DIFF
--- a/product-service/.gitignore
+++ b/product-service/.gitignore
@@ -1,0 +1,8 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+.idea

--- a/product-service/handler.js
+++ b/product-service/handler.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const PRODUCTS_MOCK = require('./products-mock');
+
+module.exports.getProductsList = async (_event) => {
+    return {
+        statusCode: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Credentials': true,
+        },
+        body: JSON.stringify(PRODUCTS_MOCK.PRODUCTS_MOCK),
+    };
+};
+
+
+module.exports.getProductsById = async (event) => {
+    const id = event.pathParameters.productId;
+
+    const product = PRODUCTS_MOCK.PRODUCTS_MOCK.find(product => product.id === id);
+
+    return {
+        statusCode: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Credentials': true,
+        },
+        body: JSON.stringify(product),
+    };
+};
+

--- a/product-service/package.json
+++ b/product-service/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "product-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/product-service/products-mock.js
+++ b/product-service/products-mock.js
@@ -1,0 +1,66 @@
+module.exports.PRODUCTS_MOCK = [
+    {
+        "count": 4,
+        "description": "Short Product Description1",
+        "id": "7567ec4b-b10c-48c5-9345-fc73c48a80aa",
+        "price": 2400,
+        "title": "Hipster-Van",
+        "imageSrc": "https://images.template.net/wp-content/uploads/2017/01/01010627/Hispter-Van-Mockup.jpg?width=600"
+    },
+    {
+        "count": 6,
+        "description": "Short Product Description3",
+        "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a0",
+        "price": 10000,
+        "title": "Truck",
+        "imageSrc": "https://images.template.net/wp-content/uploads/2017/01/01005657/Photorealistic-Truck-Mockup.jpg?width=600"
+    },
+    {
+        "count": 7,
+        "description": "Short Product Description2",
+        "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a2",
+        "price": 23000,
+        "title": "Truck",
+        "imageSrc": "https://images.template.net/wp-content/uploads/2017/01/01010542/Transport-Vehicle-Mockup.jpg?width=600"
+    },
+    {
+        "count": 12,
+        "description": "Short Product Description7",
+        "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a1",
+        "price": 15000,
+        "title": "Vehicle wrap",
+        "imageSrc": "https://images.template.net/wp-content/uploads/2017/01/01005743/Vehicle-Wrap-Mockup.jpg?width=600"
+    },
+    {
+        "count": 7,
+        "description": "Short Product Description2",
+        "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a3",
+        "price": 23000,
+        "title": "Vehicle Branding",
+        "imageSrc":"https://images.template.net/wp-content/uploads/2017/01/01005551/Vehicle-Branding-Mockup.jpg?width=600"
+    },
+    {
+        "count": 8,
+        "description": "Short Product Description4",
+        "id": "7567ec4b-b10c-48c5-9345-fc73348a80a1",
+        "price": 15000,
+        "title": "Car branding",
+        "imageSrc": "https://images.template.net/wp-content/uploads/2017/01/01005724/Car-Branding-Mockup.jpg?width=600"
+    },
+    {
+        "count": 2,
+        "description": "Short Product Descriptio1",
+        "id": "7567ec4b-b10c-48c5-9445-fc73c48a80a2",
+        "price": 23000,
+        "title": "Delivery car",
+        "imageSrc": "https://www.designbolts.com/wp-content/uploads/2020/07/FREE-Mockup-Delivery-car.jpg"
+    },
+    {
+        "count": 3,
+        "description": "Short Product Description7",
+        "id": "7567ec4b-b10c-45c5-9345-fc73c48a80a1",
+        "price": 15000,
+        "title": "Car free",
+        "imageSrc": "https://www.designbolts.com/wp-content/uploads/2020/07/Car-Free-Mockup.jpg"
+    }
+]

--- a/product-service/serverless.yml
+++ b/product-service/serverless.yml
@@ -1,0 +1,29 @@
+service: product-service
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+
+functions:
+  getProductsList:
+    handler: handler.getProductsList
+    events:
+      - http:
+          path: product
+          method: get
+          cors: true
+
+  getProductsById:
+    handler: handler.getProductsById
+    events:
+      - http:
+          path: product/{productId}
+          method: get
+          request:
+            parameters:
+              paths:
+                productId: true
+          cors: true


### PR DESCRIPTION
Frontend deploy: d1o8yilghfv46j.cloudfront.net
Frontend repo link PR: https://github.com/nadyashvedko/shop-angular-cloudfront/pull/2

added endpoints /product and /product/{id}
integrated with FE part

additional tasks aren't done

estimated mark - 4